### PR TITLE
Ensure that all icons are served over HTTPS

### DIFF
--- a/services/flickr.py
+++ b/services/flickr.py
@@ -3,8 +3,8 @@ import foauth.providers
 
 class Flickr(foauth.providers.OAuth1):
     # General info about the provider
-    provider_url = 'http://www.flickr.com/'
-    docs_url = 'http://www.flickr.com/services/api/'
+    provider_url = 'https://www.flickr.com/'
+    docs_url = 'https://www.flickr.com/services/api/'
     favicon_url = provider_url + 'favicon.ico'
     category = 'Pictures'
 

--- a/services/yahoo.py
+++ b/services/yahoo.py
@@ -6,8 +6,8 @@ import foauth.providers
 class Yahoo(foauth.providers.OAuth1):
     # General info about the provider
     name = 'Yahoo!'
-    provider_url = 'http://www.yahoo.com/'
-    docs_url = 'http://developer.yahoo.com/everything.html'
+    provider_url = 'https://www.yahoo.com/'
+    docs_url = 'https://developer.yahoo.com/everything.html'
     favicon_url = provider_url + 'favicon.ico'
     category = 'Productivity'
 


### PR DESCRIPTION
We're getting a mixed content warning because Flickr and Yahoo! are using HTTP for their favicons, instead of HTTPS. This should fix that.