### PR TITLE
Check for env vars starting with an underscore

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ app.wsgi_app = ProxyFix(app.wsgi_app)
 if 'SSLIFY' in os.environ:
     SSLify(app)
 
-
+ 
 def get_service_modules():
     for filename in glob.glob(os.path.join('services', '*.py')):
         module_name = os.path.splitext(os.path.split(filename)[1])[0]
@@ -33,9 +33,10 @@ services = []
 for module_name in get_service_modules():
     for service in get_oauth_providers(module_name):
         alias = service.alias.upper()
-        key = os.environ.get('%s_KEY' % alias, '').decode('utf8')
-        secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8')
-
+        if alias[0].isdigit():
+            underscore_alias = "_" + alias
+        key = os.environ.get('%s_KEY' % alias, '').decode or os.environ.get('%s_KEY' % underscore_alias, '').decode('utf8')
+        secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8') or os.environ.get('%s_SECRET' % underscore_alias, '').decode('utf8')
         if key and secret:  # Only initialize if all the pieces are in place
             services.append(service(key, secret))
 

--- a/config.py
+++ b/config.py
@@ -34,13 +34,15 @@ for module_name in get_service_modules():
     for service in get_oauth_providers(module_name):
         alias = service.alias.upper()
         if alias[0].isdigit():
-            underscore_alias = "_" + alias
-            key = os.environ.get('%s_KEY' % alias, '').decode('utf8') or os.environ.get('%s_KEY' % underscore_alias, '').decode('utf8')
-            secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8') or os.environ.get('%s_SECRET' % underscore_alias, '').decode('utf8')
+            key = os.environ.get('%s_KEY' % alias) or os.environ.get('_%s_KEY' % alias) or ''
+            secret = os.environ.get('%s_SECRET' % alias, '') or os.environ.get('_%s_SECRET' % alias, '') or ''
+            key = key.decode('utf8')
+            secret = secret.decode('utf8')
         else:
             key = os.environ.get('%s_KEY' % alias, '').decode('utf8')
             secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8')
-        if key and secret:  # Only initialize if all the pieces are in place
+        if key and secret:
+          # Only initialize if all the pieces are in place
             services.append(service(key, secret))
 
 

--- a/config.py
+++ b/config.py
@@ -35,8 +35,11 @@ for module_name in get_service_modules():
         alias = service.alias.upper()
         if alias[0].isdigit():
             underscore_alias = "_" + alias
-        key = os.environ.get('%s_KEY' % alias, '').decode or os.environ.get('%s_KEY' % underscore_alias, '').decode('utf8')
-        secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8') or os.environ.get('%s_SECRET' % underscore_alias, '').decode('utf8')
+            key = os.environ.get('%s_KEY' % alias, '').decode('utf8') or os.environ.get('%s_KEY' % underscore_alias, '').decode('utf8')
+            secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8') or os.environ.get('%s_SECRET' % underscore_alias, '').decode('utf8')
+        else:
+            key = os.environ.get('%s_KEY' % alias, '').decode('utf8')
+            secret = os.environ.get('%s_SECRET' % alias, '').decode('utf8')
         if key and secret:  # Only initialize if all the pieces are in place
             services.append(service(key, secret))
 


### PR DESCRIPTION
When importing environment variables and if the service name starts with a digit, check for both the service name and service name starting with an `_`