### PR TITLE
Upgrade gunicorn application server, and require gevent too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ blinker==1.2
 certifi==0.0.8
 docutils==0.10
 feedgenerator==1.5
-gunicorn==19.1.1
+gunicorn==19.2.0
 oauthlib==0.3.4
 pelican==3.5.0
 psycopg2==2.4.5
@@ -28,3 +28,4 @@ smartypants==1.6.0.3
 static==0.4
 typogrify==2.0.0
 wsgiref==0.1.2
+gevent==1.0.2


### PR DESCRIPTION
These will allow us to host foauth.org with fewer resources (by using gevent)
and will help us send stats to our statsd service (by using gunicorn 19.2.0).
